### PR TITLE
Add exclusion list to install.sh for packages to skip when stowing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,9 @@ if ! command -v stow &> /dev/null; then
   exit 1
 fi
 
+# Packages to skip when stowing (add more names as needed, e.g. tmux)
+EXCLUDE=(streamdeck)
+
 # Install dotfiles using stow
 for dir in */; do
   # Skip if directory is empty or doesn't contain files
@@ -21,6 +24,10 @@ for dir in */; do
   
   # Remove trailing slash for stow
   dir_name="${dir%/}"
+  if (( ${EXCLUDE[(I)$dir_name]} )); then
+    echo "Skipping excluded: $dir_name"
+    continue
+  fi
   echo "Stowing $dir_name..."
   
   if ! stow "$dir_name"; then


### PR DESCRIPTION
Adds a configurable exclusion list so specified packages (e.g. `streamdeck`) are skipped during `./install.sh` instead of being stowed.

**Changes:**
- Add `EXCLUDE` array after the stow check (default: `streamdeck`)
- Skip excluded directories in the loop with a clear "Skipping excluded: $dir_name" message
- Comment documents how to add more names (e.g. `tmux`)

**Usage:** To exclude more packages, add their directory names to the `EXCLUDE` array in `install.sh`.

Made with [Cursor](https://cursor.com)