### PR TITLE
feat(zsh): add git aliases, completion init, and PATH dedupe

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,6 +1,12 @@
 # Environment Variables
 export HOMEBREW_NO_ENV_HINTS=1
 
+# Dedupe PATH entries automatically
+typeset -U path PATH
+
+# Completion system
+autoload -Uz compinit && compinit
+
 # Volta (Node version manager)
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"
@@ -38,6 +44,33 @@ alias pb="pnpm run build"
 alias lg='lazygit'
 alias gcw='echo "Cloning work repo:" && git clone $(pbpaste | sed "s/github.com/github-bc/g")'
 alias gcwm='echo "Mirroring work repo:" && git clone --mirror $(pbpaste | sed "s/github.com/github-bc/g")'
+
+# Git aliases
+alias g='git'
+alias gs='git status'
+alias ga='git add'
+alias gaa='git add --all'
+alias gc='git commit -m'
+alias gca='git commit --amend'
+alias gco='git checkout'
+alias gcb='git checkout -b'
+alias gb='git branch'
+alias gbd='git branch -d'
+alias gp='git push'
+alias gpf='git push --force-with-lease'
+alias gpu='git push -u origin HEAD'
+alias gl='git pull'
+alias gf='git fetch'
+alias gfa='git fetch --all --prune'
+alias gd='git diff'
+alias gds='git diff --staged'
+alias glog='git log --oneline --graph --decorate'
+alias gst='git stash'
+alias gstp='git stash pop'
+alias gcl='git clone'
+alias gm='git merge'
+alias gr='git rebase'
+alias gri='git rebase -i'
 
 # Plugins
 eval "$(zoxide init zsh)"


### PR DESCRIPTION
## Summary

- Add standard git aliases (`gs`, `ga`, `gc`, `gp`, `gl`, `gco`, `gcb`, `glog`, etc.) for faster CLI workflow
- Initialize zsh completion system (`compinit`) so tab-completion works for git, brew, and other tools
- Add `typeset -U path PATH` to dedupe PATH entries automatically when re-sourcing `.zshrc`