### PR TITLE
chore: remove dead Volta config, document nvm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The zsh/.zshrc contains:
 - **Prompt**: Starship (cross-shell prompt)
 - **Navigation**: Zoxide (smart directory jumping with `z`)
 - **Plugins**: zsh-autosuggestions, zsh-syntax-highlighting
-- **Node management**: Volta (fast Rust-based Node version manager)
+- **Node management**: nvm (loaded from `~/.zprofile`)
 - **Aliases**: Development shortcuts for npm, pnpm, git, lazygit
 
 ### Karabiner Keyboard Remapping

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -7,10 +7,6 @@ typeset -U path PATH
 # Completion system
 autoload -Uz compinit && compinit
 
-# Volta (Node version manager)
-export VOLTA_HOME="$HOME/.volta"
-export PATH="$VOLTA_HOME/bin:$PATH"
-
 # History settings
 HISTFILE=$HOME/.zhistory
 SAVEHIST=10000


### PR DESCRIPTION
## Summary

- Remove `VOLTA_HOME` and PATH lines from `.zshrc` — Volta was never actually installed on the system, so these lines were dead code
- Update `CLAUDE.md` to reflect that **nvm** (loaded from `~/.zprofile`) is the real Node version manager in use
- No behavioral change: nvm continues to load from `~/.zprofile` as a login shell, before `.zshrc` runs